### PR TITLE
Guard getInstants() against dates where startTime is after endTime.

### DIFF
--- a/src/main/java/com/graphaware/module/timetree/SingleTimeTree.java
+++ b/src/main/java/com/graphaware/module/timetree/SingleTimeTree.java
@@ -201,6 +201,10 @@ public class SingleTimeTree implements TimeTree {
      */
     @Override
     public List<Node> getInstants(long startTime, long endTime, DateTimeZone timeZone, Resolution resolution, Transaction tx) {
+        if (startTime > endTime) {
+            throw new IllegalArgumentException("startTime must be smaller than endTime");
+        }
+
         if (timeZone == null) {
             timeZone = this.timeZone;
         }

--- a/src/test/java/com/graphaware/module/timetree/SingleTimeTreeTest.java
+++ b/src/test/java/com/graphaware/module/timetree/SingleTimeTreeTest.java
@@ -290,6 +290,19 @@ public class SingleTimeTreeTest extends DatabaseIntegrationTest {
         verifyFullTree();
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void getInstantsWithStartTimeAfterEndTimeThrows() {
+        //Given
+        long startTime = dateToMillis(2013, 1, 2);
+        long endTime = dateToMillis(2013, 1, 1);
+
+        // When
+        try (Transaction tx = getDatabase().beginTx()) {
+            timeTree.getInstants(startTime, endTime, tx);
+            // Then throw
+        }
+    }
+
     private void verifyFullTree() {
         assertSameGraph(getDatabase(), "CREATE" +
                 "(root:TimeTreeRoot)," +


### PR DESCRIPTION
Without this, the method would return an empty list in this case.
