### PR TITLE
remove spring dependency from core-implementation

### DIFF
--- a/src/main/java/com/graphaware/module/timetree/SingleTimeTree.java
+++ b/src/main/java/com/graphaware/module/timetree/SingleTimeTree.java
@@ -24,8 +24,6 @@ import org.neo4j.graphdb.*;
 import org.neo4j.tooling.GlobalGraphOperations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -45,7 +43,6 @@ import static org.neo4j.graphdb.Direction.OUTGOING;
 /**
  * Default implementation of {@link TimeTree}, which builds a single tree and maintains its own root.
  */
-@Service
 public class SingleTimeTree implements TimeTree {
 
     private static final Logger LOG = LoggerFactory.getLogger(SingleTimeTree.class);
@@ -61,7 +58,6 @@ public class SingleTimeTree implements TimeTree {
      *
      * @param database to talk to.
      */
-    @Autowired
     public SingleTimeTree(GraphDatabaseService database) {
         this.database = database;
     }


### PR DESCRIPTION
... this makes the lib more useable in non-spring projects.

alternative: update pom.xml an make spring a non-provided dependency
