### PR TITLE
Explicitly release lock on root time node.

### DIFF
--- a/src/main/java/com/graphaware/module/timetree/SingleTimeTree.java
+++ b/src/main/java/com/graphaware/module/timetree/SingleTimeTree.java
@@ -148,8 +148,9 @@ public class SingleTimeTree implements TimeTree {
             DateTime dateTime = new DateTime(timeInstant.getTime(), timeInstant.getTimezone());
 
             Node timeRoot = getTimeRoot();
-            tx.acquireWriteLock(timeRoot);
+            Lock rootLock = tx.acquireWriteLock(timeRoot);
             instant = getOrCreateInstant(timeRoot, dateTime, timeInstant.getResolution());
+            rootLock.release();
 
             tx.success();
         }


### PR DESCRIPTION
The lock is released when the tx ends, which is right after creating the new
instant. If however, there is a tx already running, then that tx is joined
and the lock is held considerably longer, leading to deadlocks.