### PR TITLE
Readonly procedures for causal cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,12 +18,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>timetree</artifactId>
-    <version>3.1.0.44.27-SNAPSHOT</version>
+    <version>3.1.3.45.27-SNAPSHOT</version>
 
     <parent>
         <groupId>com.graphaware.neo4j</groupId>
         <artifactId>module-parent</artifactId>
-        <version>3.1.1.45-SNAPSHOT</version>
+        <version>3.1.3.45</version>
     </parent>
 
     <name>GraphAware TimeTree Module</name>
@@ -101,7 +101,7 @@
             <groupId>com.graphaware.neo4j</groupId>
             <artifactId>resttest</artifactId>
             <scope>test</scope>
-            <version>3.1.0.44.15</version>
+            <version>3.1.3.45.15</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.graphaware.neo4j</groupId>
         <artifactId>module-parent</artifactId>
-        <version>3.1.0.44</version>
+        <version>3.1.1.45-SNAPSHOT</version>
     </parent>
 
     <name>GraphAware TimeTree Module</name>

--- a/src/main/java/com/graphaware/module/timetree/DefaultSingleTimeTree.java
+++ b/src/main/java/com/graphaware/module/timetree/DefaultSingleTimeTree.java
@@ -1,0 +1,666 @@
+/*
+ * Copyright (c) 2013-2016 GraphAware
+ *
+ * This file is part of the GraphAware Framework.
+ *
+ * GraphAware Framework is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of
+ * the GNU General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.graphaware.module.timetree;
+
+import static com.graphaware.common.util.PropertyContainerUtils.getInt;
+import static com.graphaware.module.timetree.SingleTimeTree.ChildNotFoundPolicy.RETURN_NEXT;
+import static com.graphaware.module.timetree.SingleTimeTree.ChildNotFoundPolicy.RETURN_NULL;
+import static com.graphaware.module.timetree.SingleTimeTree.ChildNotFoundPolicy.RETURN_PREVIOUS;
+import static com.graphaware.module.timetree.domain.Resolution.YEAR;
+import static com.graphaware.module.timetree.domain.Resolution.findForNode;
+import static com.graphaware.module.timetree.domain.TimeTreeLabels.TimeTreeRoot;
+import static com.graphaware.module.timetree.domain.TimeTreeRelationshipTypes.CHILD;
+import static com.graphaware.module.timetree.domain.TimeTreeRelationshipTypes.FIRST;
+import static com.graphaware.module.timetree.domain.TimeTreeRelationshipTypes.LAST;
+import static com.graphaware.module.timetree.domain.TimeTreeRelationshipTypes.NEXT;
+import static org.neo4j.graphdb.Direction.INCOMING;
+import static org.neo4j.graphdb.Direction.OUTGOING;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.joda.time.DateTime;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.event.TransactionData;
+import org.neo4j.graphdb.event.TransactionEventHandler;
+import org.neo4j.logging.Log;
+
+import com.graphaware.common.log.LoggerFactory;
+import com.graphaware.module.timetree.SingleTimeTree.ChildNotFoundPolicy;
+import com.graphaware.module.timetree.domain.Resolution;
+import com.graphaware.module.timetree.domain.TimeInstant;
+import com.graphaware.module.timetree.domain.TimeTreeLabels;
+
+/**
+ * Implementation of TimeTree without root-node management.
+ * get methods are readonly whereas getOrCreate one write the database 
+ */
+public class DefaultSingleTimeTree implements TimeTree {
+
+    private static final Log LOG = LoggerFactory.getLogger(DefaultSingleTimeTree.class);
+
+    protected static final String VALUE_PROPERTY = "value";
+
+    private final GraphDatabaseService database;
+    private final ReentrantLock rootLock = new ReentrantLock();
+    private final TimeRootLocator timeRootLocator;
+
+    /**
+     * Constructor for time tree.
+     *
+     * @param database to talk to.
+     */
+    public DefaultSingleTimeTree(GraphDatabaseService database, TimeRootLocator rootLocator) {
+        this.database = database;
+        this.timeRootLocator = rootLocator;
+
+        database.registerTransactionEventHandler(new TransactionEventHandler<Boolean>() {
+            @Override
+            public Boolean beforeCommit(TransactionData transactionData) throws Exception {
+                if (!rootLock.isLocked()) {
+                    return false;
+                }
+
+                for (Node node : transactionData.createdNodes()) {
+                    if (node.hasLabel(TimeTreeRoot)) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            @Override
+            public void afterCommit(TransactionData transactionData, Boolean rootCreated) {
+                if (rootCreated) {
+                    if (rootLock.isHeldByCurrentThread()) {
+                        rootLock.unlock();
+                    }
+                }
+            }
+
+            @Override
+            public void afterRollback(TransactionData transactionData, Boolean rootCreated) {
+                if (rootCreated) {
+                    if (rootLock.isHeldByCurrentThread()) {
+                        rootLock.unlock();
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Node getInstant(TimeInstant timeInstant) {
+        return getInstant(timeInstant, RETURN_NULL);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Node getInstantAtOrAfter(TimeInstant timeInstant) {
+        return getInstant(timeInstant, RETURN_NEXT);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Node getInstantAtOrBefore(TimeInstant timeInstant) {
+        return getInstant(timeInstant, RETURN_PREVIOUS);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Node> getInstants(TimeInstant startTime, TimeInstant endTime) {
+        List<Node> result = new LinkedList<>();
+
+        for (TimeInstant instant : TimeInstant.getInstants(startTime, endTime)) {
+            Node toAdd = getInstant(instant);
+            if (toAdd != null) {
+                result.add(toAdd);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Node getOrCreateInstant(TimeInstant timeInstant) {
+        Node instant;
+
+        try (Transaction tx = database.beginTx()) {
+            DateTime dateTime = new DateTime(timeInstant.getTime(), timeInstant.getTimezone());
+
+            Node timeRoot = getTimeRoot();
+            tx.acquireWriteLock(timeRoot);
+            instant = getOrCreateInstant(timeRoot, dateTime, timeInstant.getResolution());
+
+            tx.success();
+        }
+
+        return instant;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Node> getOrCreateInstants(TimeInstant startTime, TimeInstant endTime) {
+        List<Node> result = new LinkedList<>();
+
+        for (TimeInstant instant : TimeInstant.getInstants(startTime, endTime)) {
+            result.add(getOrCreateInstant(instant));
+        }
+
+        return result;
+    }
+
+    /**
+     * Get the root of the time tree. Create it if it does not exist.
+     *
+     * @return root of the time tree.
+     */
+    protected Node getTimeRoot() {
+    	return this.timeRootLocator.getTimeRoot(database, rootLock);
+    }
+
+    /**
+     * Main method for time-node seeking
+     * @param timeInstant
+     * @param childNotFoundPolicy
+     * @return
+     */
+	private Node getInstant(TimeInstant timeInstant, ChildNotFoundPolicy childNotFoundPolicy) {
+		Node result = null;
+
+		DateTime dateTime = new DateTime(timeInstant.getTime(), timeInstant.getTimezone());
+		Node timeRoot = getTimeRoot();
+
+		if (timeRoot != null) {
+			result = getInstant(timeRoot, dateTime, timeInstant.getResolution(), childNotFoundPolicy);
+		}
+
+		return result;
+	}
+
+	/**
+	 * Recursive algo to find the time-node at the given resolution
+	 * @param parent
+	 * @param dateTime
+	 * @param targetResolution
+	 * @param childNotFoundPolicy
+	 * @return
+	 */
+    private Node getInstant(Node parent, DateTime dateTime, Resolution targetResolution, ChildNotFoundPolicy childNotFoundPolicy) {
+        Resolution currentResolution = currentResolution(parent);
+
+        if (targetResolution.equals(currentResolution)) {
+            return parent;
+        }
+
+        Resolution newCurrentResolution = childResolution(parent);
+
+        Node child = findChild(parent, dateTime.get(newCurrentResolution.getDateTimeFieldType()), RETURN_NULL);
+
+        if (child == null) {
+            switch (childNotFoundPolicy) {
+                case RETURN_NULL:
+                    return null;
+                case RETURN_NEXT:
+                    return getInstantViaClosestChild(parent, dateTime, targetResolution, childNotFoundPolicy, newCurrentResolution, FIRST);
+                case RETURN_PREVIOUS:
+                    return getInstantViaClosestChild(parent, dateTime, targetResolution, childNotFoundPolicy, newCurrentResolution, LAST);
+            }
+        }
+
+        //recursion
+        return getInstant(child, dateTime, targetResolution, childNotFoundPolicy);
+    }
+
+    private Node getInstantViaClosestChild(Node parent, DateTime dateTime, Resolution targetResolution, ChildNotFoundPolicy childNotFoundPolicy, Resolution newCurrentResolution, RelationshipType relationshipType) {
+        Node closestChild = findChild(parent, dateTime.get(newCurrentResolution.getDateTimeFieldType()), childNotFoundPolicy);
+        if (closestChild == null) {
+            return null;
+        }
+        return findChild(closestChild, relationshipType, targetResolution);
+    }
+
+    /**
+     * Recursive algo to find a time-node in the tree at the target resolution
+     * @param parent
+     * @param relationshipType
+     * @param targetResolution
+     * @return
+     */
+    private Node findChild(Node parent, RelationshipType relationshipType, Resolution targetResolution) {
+        if (!isRoot(parent)) {
+            Resolution currentResolution = findForNode(parent);
+
+            if (currentResolution.equals(targetResolution)) {
+                return parent;
+            }
+        }
+
+        Relationship r = parent.getSingleRelationship(relationshipType, OUTGOING);
+        if (r == null) {
+            return null;
+        }
+
+        return findChild(r.getEndNode(), relationshipType, targetResolution);
+    }
+
+    /**
+     * Get the resolution of time of the input node
+     * @param parent
+     * @return
+     */
+    private Resolution currentResolution(Node parent) {
+        if (isRoot(parent)) {
+            return null;
+        }
+
+        return findForNode(parent);
+    }
+
+    /**
+     * Get the resolution of the input node's child
+     * @param parent
+     * @return
+     */
+    private Resolution childResolution(Node parent) {
+        if (isRoot(parent)) {
+            return YEAR;
+        }
+
+        return currentResolution(parent).getChild();
+    }
+
+    /**
+     * Get a node representing a specific time instant. If one doesn't exist, it will be created as well as any missing
+     * nodes on the way down from parent (recursively).
+     *
+     * @param parent           parent node on path to desired instant node.
+     * @param dateTime         time instant.
+     * @param targetResolution target child resolution. Recursion stops when at this level.
+     * @return node representing the time instant at the desired resolution level.
+     */
+    private Node getOrCreateInstant(Node parent, DateTime dateTime, Resolution targetResolution) {
+        Resolution currentResolution = currentResolution(parent);
+
+        if (targetResolution.equals(currentResolution)) {
+            return parent;
+        }
+
+        Resolution newCurrentResolution = childResolution(parent);
+
+        Node child = findOrCreateChild(parent, dateTime.get(newCurrentResolution.getDateTimeFieldType()));
+
+        //recursion
+        return getOrCreateInstant(child, dateTime, targetResolution);
+    }
+
+    /**
+     * Find a child node with value equal to the given value. If no such child exists, return a value according to the
+     * provided {@link ChildNotFoundPolicy}.
+     *
+     * @param parent              parent of the node to be found.
+     * @param value               value of the node to be found.
+     * @param childNotFoundPolicy what to do when child isn't found?
+     * @return child node, or a value specified by the given {@link ChildNotFoundPolicy}.
+     */
+    private Node findChild(Node parent, int value, ChildNotFoundPolicy childNotFoundPolicy) {
+        Relationship firstRelationship = parent.getSingleRelationship(FIRST, OUTGOING);
+        if (firstRelationship == null) {
+            return null;
+        }
+
+        Node existingChild = firstRelationship.getEndNode();
+        while (getInt(existingChild, VALUE_PROPERTY) < value && parent(existingChild).getId() == parent.getId()) {
+            Relationship nextRelationship = existingChild.getSingleRelationship(NEXT, OUTGOING);
+
+            if (nextRelationship == null) {
+                switch (childNotFoundPolicy) {
+                    case RETURN_NULL:
+                        return null;
+                    case RETURN_NEXT:
+                        return null;
+                    case RETURN_PREVIOUS:
+                        return existingChild;
+                }
+            }
+
+            if (parent(nextRelationship.getEndNode()).getId() != parent.getId()) {
+                switch (childNotFoundPolicy) {
+                    case RETURN_NULL:
+                        return null;
+                    case RETURN_NEXT:
+                        return nextRelationship.getEndNode();
+                    case RETURN_PREVIOUS:
+                        return existingChild;
+                }
+            }
+
+            existingChild = nextRelationship.getEndNode();
+        }
+
+        if (getInt(existingChild, VALUE_PROPERTY) == value) {
+            return existingChild;
+        }
+
+        //here we claim that getInt(existingChild, VALUE_PROPERTY) > value || parent(existingChild).getId() != parent.getId()
+        switch (childNotFoundPolicy) {
+            case RETURN_NULL:
+                return null;
+            case RETURN_NEXT:
+                return existingChild;
+            case RETURN_PREVIOUS:
+                return existingChild.getSingleRelationship(NEXT, INCOMING) == null ? null : existingChild.getSingleRelationship(NEXT, INCOMING).getStartNode();
+            default:
+                throw new IllegalStateException("Unknown child not found policy: " + childNotFoundPolicy);
+        }
+    }
+
+    /**
+     * Find a child node with value equal to the given value. If no such child exists, create one.
+     *
+     * @param parent parent of the node to be found or created.
+     * @param value  value of the node to be found or created.
+     * @return child node.
+     */
+    private Node findOrCreateChild(Node parent, int value) {
+        Relationship firstRelationship = parent.getSingleRelationship(FIRST, OUTGOING);
+        if (firstRelationship == null) {
+            return createFirstChildEver(parent, value);
+        }
+
+        Node existingChild = firstRelationship.getEndNode();
+        boolean isFirst = true;
+        while (getInt(existingChild, VALUE_PROPERTY) < value && parent(existingChild).getId() == parent.getId()) {
+            isFirst = false;
+            Relationship nextRelationship = existingChild.getSingleRelationship(NEXT, OUTGOING);
+
+            if (nextRelationship == null || parent(nextRelationship.getEndNode()).getId() != parent.getId()) {
+                return createLastChild(parent, existingChild, nextRelationship == null ? null : nextRelationship.getEndNode(), value);
+            }
+
+            existingChild = nextRelationship.getEndNode();
+        }
+
+        if (getInt(existingChild, VALUE_PROPERTY) == value) {
+            return existingChild;
+        }
+
+        Relationship previousRelationship = existingChild.getSingleRelationship(NEXT, INCOMING);
+
+        if (isFirst) {
+            return createFirstChild(parent, previousRelationship == null ? null : previousRelationship.getStartNode(), existingChild, value);
+        }
+
+        return createChild(parent, previousRelationship.getStartNode(), existingChild, value);
+    }
+
+    /**
+     * Create the first ever child of a parent.
+     *
+     * @param parent to create child for.
+     * @param value  value of the node to be created.
+     * @return child node.
+     */
+    private Node createFirstChildEver(Node parent, int value) {
+        if (parent.getSingleRelationship(LAST, OUTGOING) != null) { //sanity check
+            LOG.error(parent + " has no " + FIRST + " relationship, but has a " + LAST + " one!");
+            throw new IllegalStateException(parent + " has no " + FIRST + " relationship, but has a " + LAST + " one!");
+        }
+
+        Node previousChild = null;
+        Node previousParent = parent;
+        while (previousChild == null) {
+            Relationship previousParentRelationship = previousParent.getSingleRelationship(NEXT, INCOMING);
+            if (previousParentRelationship == null) {
+                break;
+            }
+
+            previousParent = previousParentRelationship.getStartNode();
+            Relationship currentParentLastChildRelationship = previousParent.getSingleRelationship(LAST, OUTGOING);
+            if (currentParentLastChildRelationship != null) {
+                previousChild = currentParentLastChildRelationship.getEndNode();
+            }
+        }
+
+        Node nextChild = null;
+        Node nextParent = parent;
+        while (nextChild == null) {
+            Relationship nextParentRelationship = nextParent.getSingleRelationship(NEXT, OUTGOING);
+            if (nextParentRelationship == null) {
+                break;
+            }
+
+            nextParent = nextParentRelationship.getEndNode();
+            Relationship nextParentFirstChildRelationship = nextParent.getSingleRelationship(FIRST, OUTGOING);
+            if (nextParentFirstChildRelationship != null) {
+                nextChild = nextParentFirstChildRelationship.getEndNode();
+            }
+        }
+
+        Node child = createChild(parent, previousChild, nextChild, value);
+
+        parent.createRelationshipTo(child, FIRST);
+        parent.createRelationshipTo(child, LAST);
+
+        return child;
+    }
+
+    /**
+     * Create the first child node that belongs to a specific parent. "First" is with respect to ordering, not the
+     * number of nodes. In other words, the node being created is not the first parent's child, but it is the child with
+     * the lowest ordering.
+     *
+     * @param parent        to create child for.
+     * @param previousChild previous child (has different parent), or null for no such child.
+     * @param nextChild     next child (has same parent).
+     * @param value         value of the node to be created.
+     * @return child node.
+     */
+    private Node createFirstChild(Node parent, Node previousChild, Node nextChild, int value) {
+        Relationship firstRelationship = parent.getSingleRelationship(FIRST, OUTGOING);
+
+        if (nextChild.getId() != firstRelationship.getEndNode().getId()) { //sanity check
+            LOG.error(nextChild + " seems to be the first child of node " + parent + ", but there is no " + FIRST + " relationship between the two!");
+            throw new IllegalStateException(nextChild + " seems to be the first child of node " + parent + ", but there is no " + FIRST + " relationship between the two!");
+        }
+
+        firstRelationship.delete();
+
+        Node child = createChild(parent, previousChild, nextChild, value);
+
+        parent.createRelationshipTo(child, FIRST);
+
+        return child;
+    }
+
+    /**
+     * Create the last child node that belongs to a specific parent.
+     *
+     * @param parent        to create child for.
+     * @param previousChild previous child (has same parent).
+     * @param nextChild     next child (has different parent), or null for no such child.
+     * @param value         value of the node to be created.
+     * @return child node.
+     */
+    private Node createLastChild(Node parent, Node previousChild, Node nextChild, int value) {
+        Relationship lastRelationship = parent.getSingleRelationship(LAST, OUTGOING);
+
+        Node endNode = lastRelationship.getEndNode();
+        if (previousChild.getId() != endNode.getId()) { //sanity check
+            LOG.error(previousChild + " seems to be the last child of node " + parent + ", but there is no " + LAST + " relationship between the two!");
+            throw new IllegalStateException(previousChild + " seems to be the last child of node " + parent + ", but there is no " + LAST + " relationship between the two!");
+        }
+
+        lastRelationship.delete();
+
+        Node child = createChild(parent, previousChild, nextChild, value);
+
+        parent.createRelationshipTo(child, LAST);
+
+        return child;
+    }
+
+    /**
+     * Create a child node.
+     *
+     * @param parent   parent node.
+     * @param previous previous node on the same level, null if the child is the first one.
+     * @param next     next node on the same level, null if the child is the last one.
+     * @param value    value of the child.
+     * @return the newly created child.
+     */
+    private Node createChild(Node parent, Node previous, Node next, int value) {
+        if (previous != null && next != null && next.getId() != previous.getSingleRelationship(NEXT, OUTGOING).getEndNode().getId()) {
+            LOG.error(previous + " and " + next + " are not connected with a " + NEXT + " relationship!");
+            throw new IllegalArgumentException(previous + " and " + next + " are not connected with a " + NEXT + " relationship!");
+        }
+
+        Node child = database.createNode(TimeTreeLabels.getChild(parent));
+        child.setProperty(VALUE_PROPERTY, value);
+        parent.createRelationshipTo(child, CHILD);
+
+        if (previous != null) {
+            Relationship nextRelationship = previous.getSingleRelationship(NEXT, OUTGOING);
+            if (nextRelationship != null) {
+                nextRelationship.delete();
+            }
+            previous.createRelationshipTo(child, NEXT);
+        }
+
+        if (next != null) {
+            child.createRelationshipTo(next, NEXT);
+        }
+
+        return child;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeAll() {
+        removeChildren(getTimeRoot());
+    }
+
+    private void removeChildren(Node root) {
+        for (Relationship relationship : root.getRelationships(OUTGOING)) {
+            relationship.delete();
+            if (relationship.isType(CHILD)) {
+                removeChildren(relationship.getEndNode());
+            }
+        }
+        root.delete();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeInstant(Node instantNode) {
+        if (instantNode.hasRelationship(CHILD, OUTGOING)) {
+            LOG.warn("Cannot remove " + instantNode + ". It still has children.");
+            return;
+        }
+
+        Relationship first = instantNode.getSingleRelationship(FIRST, INCOMING);
+        Relationship last = instantNode.getSingleRelationship(LAST, INCOMING);
+
+        Relationship prev = instantNode.getSingleRelationship(NEXT, INCOMING);
+        Relationship next = instantNode.getSingleRelationship(NEXT, OUTGOING);
+
+        if (prev != null && next != null) {  // middle
+            if (last != null) {
+                last.getStartNode().createRelationshipTo(prev.getStartNode(), LAST);
+                last.delete();
+            }
+            if (first != null) {
+                first.getStartNode().createRelationshipTo(next.getEndNode(), FIRST);
+                first.delete();
+            }
+
+            prev.getStartNode().createRelationshipTo(next.getEndNode(), NEXT);
+            prev.delete();
+            next.delete();
+        } else if (first != null && next != null) { // beginning
+            first.getStartNode().createRelationshipTo(next.getEndNode(), FIRST);
+            first.delete();
+            next.delete();
+        } else if (prev != null && last != null) { // end
+            last.getStartNode().createRelationshipTo(prev.getStartNode(), LAST);
+            last.delete();
+            prev.delete();
+        }
+
+
+        if (instantNode.hasRelationship(FIRST, OUTGOING)) {
+            instantNode.getSingleRelationship(FIRST, OUTGOING).delete();
+        }
+
+        if (instantNode.hasRelationship(LAST, OUTGOING)) {
+            instantNode.getSingleRelationship(LAST, OUTGOING).delete();
+        }
+
+        if (instantNode.hasRelationship(CHILD, INCOMING)) {
+            Relationship toParent = instantNode.getSingleRelationship(CHILD, INCOMING);
+            toParent.delete();
+            removeInstant(toParent.getStartNode());
+        }
+        instantNode.delete();
+    }
+
+    /**
+     * Find the parent of a node.
+     *
+     * @param node to find a parent for.
+     * @return parent.
+     * @throws IllegalStateException in case the node has no parent.
+     */
+    static Node parent(Node node) {
+        Relationship parentRelationship = node.getSingleRelationship(CHILD, INCOMING);
+
+        if (parentRelationship == null) {
+            LOG.error(node + " has no parent!");
+            throw new IllegalStateException(node + " has no parent!");
+        }
+
+        return parentRelationship.getStartNode();
+    }
+
+    private boolean isRoot(Node node) {
+        return node.getId() == getTimeRoot().getId();
+    }
+}

--- a/src/main/java/com/graphaware/module/timetree/SingleTimeTree.java
+++ b/src/main/java/com/graphaware/module/timetree/SingleTimeTree.java
@@ -16,84 +16,113 @@
 
 package com.graphaware.module.timetree;
 
-import com.graphaware.common.log.LoggerFactory;
-import com.graphaware.common.util.IterableUtils;
-import com.graphaware.module.timetree.domain.Resolution;
-import com.graphaware.module.timetree.domain.TimeInstant;
-import com.graphaware.module.timetree.domain.TimeTreeLabels;
-import org.joda.time.DateTime;
-import org.neo4j.graphdb.*;
-import org.neo4j.graphdb.event.TransactionData;
-import org.neo4j.graphdb.event.TransactionEventHandler;
-import org.neo4j.logging.Log;
+import static com.graphaware.module.timetree.domain.TimeTreeLabels.TimeTreeRoot;
+import static com.graphaware.module.timetree.domain.TimeTreeRelationshipTypes.CHILD;
+import static org.neo4j.graphdb.Direction.INCOMING;
 
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static com.graphaware.common.util.PropertyContainerUtils.getInt;
-import static com.graphaware.module.timetree.SingleTimeTree.ChildNotFoundPolicy.*;
-import static com.graphaware.module.timetree.domain.Resolution.YEAR;
-import static com.graphaware.module.timetree.domain.Resolution.findForNode;
-import static com.graphaware.module.timetree.domain.TimeTreeLabels.TimeTreeRoot;
-import static com.graphaware.module.timetree.domain.TimeTreeRelationshipTypes.*;
-import static org.neo4j.graphdb.Direction.INCOMING;
-import static org.neo4j.graphdb.Direction.OUTGOING;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.NotFoundException;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.logging.Log;
+
+import com.graphaware.common.log.LoggerFactory;
+import com.graphaware.common.util.IterableUtils;
+import com.graphaware.module.timetree.domain.TimeInstant;
 
 /**
- * Default implementation of {@link TimeTree}, which builds a single tree and maintains its own root.
+ * Facade for {@link TimeTree}, delegating to {@link DefaultSingleTimeTree} implementation.
  */
 public class SingleTimeTree implements TimeTree {
 
+	/*	2017-03 - Causal Cluster
+	 * 	Introducing causal cluster compatibility, this implementation changed in order to have readonly operations.
+	 * 	Readonly operations can run in FOLLOWER and (most important) in READ_REPLICA instances: this means to scale the readers.
+	 */
+	
     private static final Log LOG = LoggerFactory.getLogger(SingleTimeTree.class);
 
-    protected static final String VALUE_PROPERTY = "value";
+    protected static final String VALUE_PROPERTY = DefaultSingleTimeTree.VALUE_PROPERTY;
+    
+    /**
+     * Used when create=false
+     */
+    private TimeTree readOnlyTree;
+    
+    private TimeTree writableTree;
+    
+    enum ChildNotFoundPolicy {
+        RETURN_NULL, RETURN_PREVIOUS, RETURN_NEXT
+    }
 
-    private final GraphDatabaseService database;
-    private final ReentrantLock rootLock = new ReentrantLock();
-
+    /**
+     * Time tree without root management
+     * @param database to talk to.
+     * @param rootLocator custom root-node retrieving algo
+     */
+    public SingleTimeTree(GraphDatabaseService database, TimeRootLocator rootLocator) {
+    	this.readOnlyTree = new DefaultSingleTimeTree(database, rootLocator);
+    	this.writableTree = this.readOnlyTree;
+    }
+    
     /**
      * Constructor for time tree.
      *
      * @param database to talk to.
      */
     public SingleTimeTree(GraphDatabaseService database) {
-        this.database = database;
+    	readOnlyTree = new DefaultSingleTimeTree(database, new TimeRootLocator() {
+			
+			@Override
+			public Node getTimeRoot(GraphDatabaseService database, ReentrantLock rootLock) {
+		        Node timeTreeRoot = IterableUtils.getSingleOrNull(database.findNodes(TimeTreeRoot));
 
-        database.registerTransactionEventHandler(new TransactionEventHandler<Boolean>() {
-            @Override
-            public Boolean beforeCommit(TransactionData transactionData) throws Exception {
-                if (!rootLock.isLocked()) {
-                    return false;
-                }
+		        if (timeTreeRoot != null) {
+		            try {
+		                timeTreeRoot.getDegree();
+		                return timeTreeRoot;
+		            } catch (NotFoundException e) {
+		                //ok
+		            }
+		        }
 
-                for (Node node : transactionData.createdNodes()) {
-                    if (node.hasLabel(TimeTreeRoot)) {
-                        return true;
-                    }
-                }
+		        return timeTreeRoot;
+			}
+		});
+    	
+    	writableTree = new DefaultSingleTimeTree(database, new TimeRootLocator() {
+			
+			@Override
+			public Node getTimeRoot(GraphDatabaseService database, ReentrantLock rootLock) {
+		        Node timeTreeRoot = IterableUtils.getSingleOrNull(database.findNodes(TimeTreeRoot));
 
-                return false;
-            }
+		        if (timeTreeRoot != null) {
+		            try {
+		                timeTreeRoot.getDegree();
+		                return timeTreeRoot;
+		            } catch (NotFoundException e) {
+		                //ok
+		            }
+		        }
 
-            @Override
-            public void afterCommit(TransactionData transactionData, Boolean rootCreated) {
-                if (rootCreated) {
-                    if (rootLock.isHeldByCurrentThread()) {
-                        rootLock.unlock();
-                    }
-                }
-            }
+		        rootLock.lock();
 
-            @Override
-            public void afterRollback(TransactionData transactionData, Boolean rootCreated) {
-                if (rootCreated) {
-                    if (rootLock.isHeldByCurrentThread()) {
-                        rootLock.unlock();
-                    }
-                }
-            }
-        });
+		        timeTreeRoot = IterableUtils.getSingleOrNull(database.findNodes(TimeTreeRoot));
+
+		        if (timeTreeRoot != null) {
+		            rootLock.unlock();
+		            return timeTreeRoot;
+		        }
+
+		        LOG.info("Creating time tree root");
+		        timeTreeRoot = database.createNode(TimeTreeRoot);
+
+		        return timeTreeRoot;
+			}
+		});
     }
 
     /**
@@ -101,7 +130,7 @@ public class SingleTimeTree implements TimeTree {
      */
     @Override
     public Node getInstant(TimeInstant timeInstant) {
-        return getInstant(timeInstant, RETURN_NULL);
+    	return this.readOnlyTree.getInstant(timeInstant);
     }
 
     /**
@@ -109,7 +138,7 @@ public class SingleTimeTree implements TimeTree {
      */
     @Override
     public Node getInstantAtOrAfter(TimeInstant timeInstant) {
-        return getInstant(timeInstant, RETURN_NEXT);
+    	return this.readOnlyTree.getInstantAtOrAfter(timeInstant);
     }
 
     /**
@@ -117,7 +146,7 @@ public class SingleTimeTree implements TimeTree {
      */
     @Override
     public Node getInstantAtOrBefore(TimeInstant timeInstant) {
-        return getInstant(timeInstant, RETURN_PREVIOUS);
+    	return this.readOnlyTree.getInstantAtOrBefore(timeInstant);
     }
 
     /**
@@ -125,16 +154,7 @@ public class SingleTimeTree implements TimeTree {
      */
     @Override
     public List<Node> getInstants(TimeInstant startTime, TimeInstant endTime) {
-        List<Node> result = new LinkedList<>();
-
-        for (TimeInstant instant : TimeInstant.getInstants(startTime, endTime)) {
-            Node toAdd = getInstant(instant);
-            if (toAdd != null) {
-                result.add(toAdd);
-            }
-        }
-
-        return result;
+        return this.readOnlyTree.getInstants(startTime, endTime);
     }
 
     /**
@@ -142,19 +162,7 @@ public class SingleTimeTree implements TimeTree {
      */
     @Override
     public Node getOrCreateInstant(TimeInstant timeInstant) {
-        Node instant;
-
-        try (Transaction tx = database.beginTx()) {
-            DateTime dateTime = new DateTime(timeInstant.getTime(), timeInstant.getTimezone());
-
-            Node timeRoot = getTimeRoot();
-            tx.acquireWriteLock(timeRoot);
-            instant = getOrCreateInstant(timeRoot, dateTime, timeInstant.getResolution());
-
-            tx.success();
-        }
-
-        return instant;
+        return this.writableTree.getOrCreateInstant(timeInstant);
     }
 
     /**
@@ -162,471 +170,25 @@ public class SingleTimeTree implements TimeTree {
      */
     @Override
     public List<Node> getOrCreateInstants(TimeInstant startTime, TimeInstant endTime) {
-        List<Node> result = new LinkedList<>();
-
-        for (TimeInstant instant : TimeInstant.getInstants(startTime, endTime)) {
-            result.add(getOrCreateInstant(instant));
-        }
-
-        return result;
+        return this.writableTree.getOrCreateInstants(startTime, endTime);
     }
 
-    /**
-     * Get the root of the time tree. Create it if it does not exist.
-     *
-     * @return root of the time tree.
-     */
-    protected Node getTimeRoot() {
-        Node timeTreeRoot = IterableUtils.getSingleOrNull(database.findNodes(TimeTreeRoot));
-
-        if (timeTreeRoot != null) {
-            try {
-                timeTreeRoot.getDegree();
-                return timeTreeRoot;
-            } catch (NotFoundException e) {
-                //ok
-            }
-        }
-
-        rootLock.lock();
-
-        timeTreeRoot = IterableUtils.getSingleOrNull(database.findNodes(TimeTreeRoot));
-
-        if (timeTreeRoot != null) {
-            rootLock.unlock();
-            return timeTreeRoot;
-        }
-
-        LOG.info("Creating time tree root");
-        timeTreeRoot = database.createNode(TimeTreeRoot);
-
-        return timeTreeRoot;
-    }
-
-    private Node getInstant(TimeInstant timeInstant, ChildNotFoundPolicy childNotFoundPolicy) {
-        Node instant;
-
-        try (Transaction tx = database.beginTx()) {
-            DateTime dateTime = new DateTime(timeInstant.getTime(), timeInstant.getTimezone());
-
-            Node timeRoot = getTimeRoot();
-            tx.acquireWriteLock(timeRoot);
-
-            instant = getInstant(timeRoot, dateTime, timeInstant.getResolution(), childNotFoundPolicy);
-
-            tx.success();
-        }
-
-        return instant;
-    }
-
-    private Node getInstant(Node parent, DateTime dateTime, Resolution targetResolution, ChildNotFoundPolicy childNotFoundPolicy) {
-        Resolution currentResolution = currentResolution(parent);
-
-        if (targetResolution.equals(currentResolution)) {
-            return parent;
-        }
-
-        Resolution newCurrentResolution = childResolution(parent);
-
-        Node child = findChild(parent, dateTime.get(newCurrentResolution.getDateTimeFieldType()), RETURN_NULL);
-
-        if (child == null) {
-            switch (childNotFoundPolicy) {
-                case RETURN_NULL:
-                    return null;
-                case RETURN_NEXT:
-                    return getInstantViaClosestChild(parent, dateTime, targetResolution, childNotFoundPolicy, newCurrentResolution, FIRST);
-                case RETURN_PREVIOUS:
-                    return getInstantViaClosestChild(parent, dateTime, targetResolution, childNotFoundPolicy, newCurrentResolution, LAST);
-            }
-        }
-
-        //recursion
-        return getInstant(child, dateTime, targetResolution, childNotFoundPolicy);
-    }
-
-    private Node getInstantViaClosestChild(Node parent, DateTime dateTime, Resolution targetResolution, ChildNotFoundPolicy childNotFoundPolicy, Resolution newCurrentResolution, RelationshipType relationshipType) {
-        Node closestChild = findChild(parent, dateTime.get(newCurrentResolution.getDateTimeFieldType()), childNotFoundPolicy);
-        if (closestChild == null) {
-            return null;
-        }
-        return findChild(closestChild, relationshipType, targetResolution);
-    }
-
-    private Node findChild(Node parent, RelationshipType relationshipType, Resolution targetResolution) {
-        if (!isRoot(parent)) {
-            Resolution currentResolution = findForNode(parent);
-
-            if (currentResolution.equals(targetResolution)) {
-                return parent;
-            }
-        }
-
-        Relationship r = parent.getSingleRelationship(relationshipType, OUTGOING);
-        if (r == null) {
-            return null;
-        }
-
-        return findChild(r.getEndNode(), relationshipType, targetResolution);
-    }
-
-    private Resolution currentResolution(Node parent) {
-        if (isRoot(parent)) {
-            return null;
-        }
-
-        return findForNode(parent);
-    }
-
-    private Resolution childResolution(Node parent) {
-        if (isRoot(parent)) {
-            return YEAR;
-        }
-
-        return currentResolution(parent).getChild();
-    }
-
-    enum ChildNotFoundPolicy {
-        RETURN_NULL, RETURN_PREVIOUS, RETURN_NEXT
-    }
-
-    /**
-     * Get a node representing a specific time instant. If one doesn't exist, it will be created as well as any missing
-     * nodes on the way down from parent (recursively).
-     *
-     * @param parent           parent node on path to desired instant node.
-     * @param dateTime         time instant.
-     * @param targetResolution target child resolution. Recursion stops when at this level.
-     * @return node representing the time instant at the desired resolution level.
-     */
-    private Node getOrCreateInstant(Node parent, DateTime dateTime, Resolution targetResolution) {
-        Resolution currentResolution = currentResolution(parent);
-
-        if (targetResolution.equals(currentResolution)) {
-            return parent;
-        }
-
-        Resolution newCurrentResolution = childResolution(parent);
-
-        Node child = findOrCreateChild(parent, dateTime.get(newCurrentResolution.getDateTimeFieldType()));
-
-        //recursion
-        return getOrCreateInstant(child, dateTime, targetResolution);
-    }
-
-    /**
-     * Find a child node with value equal to the given value. If no such child exists, return a value according to the
-     * provided {@link ChildNotFoundPolicy}.
-     *
-     * @param parent              parent of the node to be found.
-     * @param value               value of the node to be found.
-     * @param childNotFoundPolicy what to do when child isn't found?
-     * @return child node, or a value specified by the given {@link ChildNotFoundPolicy}.
-     */
-    private Node findChild(Node parent, int value, ChildNotFoundPolicy childNotFoundPolicy) {
-        Relationship firstRelationship = parent.getSingleRelationship(FIRST, OUTGOING);
-        if (firstRelationship == null) {
-            return null;
-        }
-
-        Node existingChild = firstRelationship.getEndNode();
-        while (getInt(existingChild, VALUE_PROPERTY) < value && parent(existingChild).getId() == parent.getId()) {
-            Relationship nextRelationship = existingChild.getSingleRelationship(NEXT, OUTGOING);
-
-            if (nextRelationship == null) {
-                switch (childNotFoundPolicy) {
-                    case RETURN_NULL:
-                        return null;
-                    case RETURN_NEXT:
-                        return null;
-                    case RETURN_PREVIOUS:
-                        return existingChild;
-                }
-            }
-
-            if (parent(nextRelationship.getEndNode()).getId() != parent.getId()) {
-                switch (childNotFoundPolicy) {
-                    case RETURN_NULL:
-                        return null;
-                    case RETURN_NEXT:
-                        return nextRelationship.getEndNode();
-                    case RETURN_PREVIOUS:
-                        return existingChild;
-                }
-            }
-
-            existingChild = nextRelationship.getEndNode();
-        }
-
-        if (getInt(existingChild, VALUE_PROPERTY) == value) {
-            return existingChild;
-        }
-
-        //here we claim that getInt(existingChild, VALUE_PROPERTY) > value || parent(existingChild).getId() != parent.getId()
-        switch (childNotFoundPolicy) {
-            case RETURN_NULL:
-                return null;
-            case RETURN_NEXT:
-                return existingChild;
-            case RETURN_PREVIOUS:
-                return existingChild.getSingleRelationship(NEXT, INCOMING) == null ? null : existingChild.getSingleRelationship(NEXT, INCOMING).getStartNode();
-            default:
-                throw new IllegalStateException("Unknown child not found policy: " + childNotFoundPolicy);
-        }
-    }
-
-    /**
-     * Find a child node with value equal to the given value. If no such child exists, create one.
-     *
-     * @param parent parent of the node to be found or created.
-     * @param value  value of the node to be found or created.
-     * @return child node.
-     */
-    private Node findOrCreateChild(Node parent, int value) {
-        Relationship firstRelationship = parent.getSingleRelationship(FIRST, OUTGOING);
-        if (firstRelationship == null) {
-            return createFirstChildEver(parent, value);
-        }
-
-        Node existingChild = firstRelationship.getEndNode();
-        boolean isFirst = true;
-        while (getInt(existingChild, VALUE_PROPERTY) < value && parent(existingChild).getId() == parent.getId()) {
-            isFirst = false;
-            Relationship nextRelationship = existingChild.getSingleRelationship(NEXT, OUTGOING);
-
-            if (nextRelationship == null || parent(nextRelationship.getEndNode()).getId() != parent.getId()) {
-                return createLastChild(parent, existingChild, nextRelationship == null ? null : nextRelationship.getEndNode(), value);
-            }
-
-            existingChild = nextRelationship.getEndNode();
-        }
-
-        if (getInt(existingChild, VALUE_PROPERTY) == value) {
-            return existingChild;
-        }
-
-        Relationship previousRelationship = existingChild.getSingleRelationship(NEXT, INCOMING);
-
-        if (isFirst) {
-            return createFirstChild(parent, previousRelationship == null ? null : previousRelationship.getStartNode(), existingChild, value);
-        }
-
-        return createChild(parent, previousRelationship.getStartNode(), existingChild, value);
-    }
-
-    /**
-     * Create the first ever child of a parent.
-     *
-     * @param parent to create child for.
-     * @param value  value of the node to be created.
-     * @return child node.
-     */
-    private Node createFirstChildEver(Node parent, int value) {
-        if (parent.getSingleRelationship(LAST, OUTGOING) != null) { //sanity check
-            LOG.error(parent + " has no " + FIRST + " relationship, but has a " + LAST + " one!");
-            throw new IllegalStateException(parent + " has no " + FIRST + " relationship, but has a " + LAST + " one!");
-        }
-
-        Node previousChild = null;
-        Node previousParent = parent;
-        while (previousChild == null) {
-            Relationship previousParentRelationship = previousParent.getSingleRelationship(NEXT, INCOMING);
-            if (previousParentRelationship == null) {
-                break;
-            }
-
-            previousParent = previousParentRelationship.getStartNode();
-            Relationship currentParentLastChildRelationship = previousParent.getSingleRelationship(LAST, OUTGOING);
-            if (currentParentLastChildRelationship != null) {
-                previousChild = currentParentLastChildRelationship.getEndNode();
-            }
-        }
-
-        Node nextChild = null;
-        Node nextParent = parent;
-        while (nextChild == null) {
-            Relationship nextParentRelationship = nextParent.getSingleRelationship(NEXT, OUTGOING);
-            if (nextParentRelationship == null) {
-                break;
-            }
-
-            nextParent = nextParentRelationship.getEndNode();
-            Relationship nextParentFirstChildRelationship = nextParent.getSingleRelationship(FIRST, OUTGOING);
-            if (nextParentFirstChildRelationship != null) {
-                nextChild = nextParentFirstChildRelationship.getEndNode();
-            }
-        }
-
-        Node child = createChild(parent, previousChild, nextChild, value);
-
-        parent.createRelationshipTo(child, FIRST);
-        parent.createRelationshipTo(child, LAST);
-
-        return child;
-    }
-
-    /**
-     * Create the first child node that belongs to a specific parent. "First" is with respect to ordering, not the
-     * number of nodes. In other words, the node being created is not the first parent's child, but it is the child with
-     * the lowest ordering.
-     *
-     * @param parent        to create child for.
-     * @param previousChild previous child (has different parent), or null for no such child.
-     * @param nextChild     next child (has same parent).
-     * @param value         value of the node to be created.
-     * @return child node.
-     */
-    private Node createFirstChild(Node parent, Node previousChild, Node nextChild, int value) {
-        Relationship firstRelationship = parent.getSingleRelationship(FIRST, OUTGOING);
-
-        if (nextChild.getId() != firstRelationship.getEndNode().getId()) { //sanity check
-            LOG.error(nextChild + " seems to be the first child of node " + parent + ", but there is no " + FIRST + " relationship between the two!");
-            throw new IllegalStateException(nextChild + " seems to be the first child of node " + parent + ", but there is no " + FIRST + " relationship between the two!");
-        }
-
-        firstRelationship.delete();
-
-        Node child = createChild(parent, previousChild, nextChild, value);
-
-        parent.createRelationshipTo(child, FIRST);
-
-        return child;
-    }
-
-    /**
-     * Create the last child node that belongs to a specific parent.
-     *
-     * @param parent        to create child for.
-     * @param previousChild previous child (has same parent).
-     * @param nextChild     next child (has different parent), or null for no such child.
-     * @param value         value of the node to be created.
-     * @return child node.
-     */
-    private Node createLastChild(Node parent, Node previousChild, Node nextChild, int value) {
-        Relationship lastRelationship = parent.getSingleRelationship(LAST, OUTGOING);
-
-        Node endNode = lastRelationship.getEndNode();
-        if (previousChild.getId() != endNode.getId()) { //sanity check
-            LOG.error(previousChild + " seems to be the last child of node " + parent + ", but there is no " + LAST + " relationship between the two!");
-            throw new IllegalStateException(previousChild + " seems to be the last child of node " + parent + ", but there is no " + LAST + " relationship between the two!");
-        }
-
-        lastRelationship.delete();
-
-        Node child = createChild(parent, previousChild, nextChild, value);
-
-        parent.createRelationshipTo(child, LAST);
-
-        return child;
-    }
-
-    /**
-     * Create a child node.
-     *
-     * @param parent   parent node.
-     * @param previous previous node on the same level, null if the child is the first one.
-     * @param next     next node on the same level, null if the child is the last one.
-     * @param value    value of the child.
-     * @return the newly created child.
-     */
-    private Node createChild(Node parent, Node previous, Node next, int value) {
-        if (previous != null && next != null && next.getId() != previous.getSingleRelationship(NEXT, OUTGOING).getEndNode().getId()) {
-            LOG.error(previous + " and " + next + " are not connected with a " + NEXT + " relationship!");
-            throw new IllegalArgumentException(previous + " and " + next + " are not connected with a " + NEXT + " relationship!");
-        }
-
-        Node child = database.createNode(TimeTreeLabels.getChild(parent));
-        child.setProperty(VALUE_PROPERTY, value);
-        parent.createRelationshipTo(child, CHILD);
-
-        if (previous != null) {
-            Relationship nextRelationship = previous.getSingleRelationship(NEXT, OUTGOING);
-            if (nextRelationship != null) {
-                nextRelationship.delete();
-            }
-            previous.createRelationshipTo(child, NEXT);
-        }
-
-        if (next != null) {
-            child.createRelationshipTo(next, NEXT);
-        }
-
-        return child;
-    }
-
+ 
     /**
      * {@inheritDoc}
      */
     @Override
     public void removeAll() {
-        removeChildren(getTimeRoot());
+    	this.writableTree.removeAll();
     }
 
-    private void removeChildren(Node root) {
-        for (Relationship relationship : root.getRelationships(OUTGOING)) {
-            relationship.delete();
-            if (relationship.isType(CHILD)) {
-                removeChildren(relationship.getEndNode());
-            }
-        }
-        root.delete();
-    }
 
     /**
      * {@inheritDoc}
      */
     @Override
     public void removeInstant(Node instantNode) {
-        if (instantNode.hasRelationship(CHILD, OUTGOING)) {
-            LOG.warn("Cannot remove " + instantNode + ". It still has children.");
-            return;
-        }
-
-        Relationship first = instantNode.getSingleRelationship(FIRST, INCOMING);
-        Relationship last = instantNode.getSingleRelationship(LAST, INCOMING);
-
-        Relationship prev = instantNode.getSingleRelationship(NEXT, INCOMING);
-        Relationship next = instantNode.getSingleRelationship(NEXT, OUTGOING);
-
-        if (prev != null && next != null) {  // middle
-            if (last != null) {
-                last.getStartNode().createRelationshipTo(prev.getStartNode(), LAST);
-                last.delete();
-            }
-            if (first != null) {
-                first.getStartNode().createRelationshipTo(next.getEndNode(), FIRST);
-                first.delete();
-            }
-
-            prev.getStartNode().createRelationshipTo(next.getEndNode(), NEXT);
-            prev.delete();
-            next.delete();
-        } else if (first != null && next != null) { // beginning
-            first.getStartNode().createRelationshipTo(next.getEndNode(), FIRST);
-            first.delete();
-            next.delete();
-        } else if (prev != null && last != null) { // end
-            last.getStartNode().createRelationshipTo(prev.getStartNode(), LAST);
-            last.delete();
-            prev.delete();
-        }
-
-
-        if (instantNode.hasRelationship(FIRST, OUTGOING)) {
-            instantNode.getSingleRelationship(FIRST, OUTGOING).delete();
-        }
-
-        if (instantNode.hasRelationship(LAST, OUTGOING)) {
-            instantNode.getSingleRelationship(LAST, OUTGOING).delete();
-        }
-
-        if (instantNode.hasRelationship(CHILD, INCOMING)) {
-            Relationship toParent = instantNode.getSingleRelationship(CHILD, INCOMING);
-            toParent.delete();
-            removeInstant(toParent.getStartNode());
-        }
-        instantNode.delete();
+    	this.writableTree.removeInstant(instantNode);
     }
 
     /**
@@ -647,7 +209,4 @@ public class SingleTimeTree implements TimeTree {
         return parentRelationship.getStartNode();
     }
 
-    private boolean isRoot(Node node) {
-        return node.getId() == getTimeRoot().getId();
-    }
 }

--- a/src/main/java/com/graphaware/module/timetree/TimeRootLocator.java
+++ b/src/main/java/com/graphaware/module/timetree/TimeRootLocator.java
@@ -13,7 +13,6 @@
  * the GNU General Public License along with this program.  If not, see
  * <http://www.gnu.org/licenses/>.
  */
-
 package com.graphaware.module.timetree;
 
 import java.util.concurrent.locks.ReentrantLock;
@@ -22,22 +21,15 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 
 /**
- * An implementation of {@link TimeTree} which can have a custom time tree root provided to it. Thus, it allows for many
- * different time trees within a single graph.
+ * retrieve the time root node of a time tree
  */
-public class CustomRootTimeTree extends SingleTimeTree {
+public interface TimeRootLocator {
 	
 	/**
-	 * TimeTree attached to the input node (root)
-	 * @param root the root-node of time tree
+	 * Get (or create) the root node of the time-tree
+	 * @param database
+	 * @param rootLock
+	 * @return
 	 */
-    public CustomRootTimeTree(Node root) {
-    	super(root.getGraphDatabase(),new TimeRootLocator() {
-			
-			@Override
-			public Node getTimeRoot(GraphDatabaseService database, ReentrantLock rootLock) {
-				return root;
-			}
-		});
-    }
+	public Node getTimeRoot(GraphDatabaseService database, ReentrantLock rootLock);
 }

--- a/src/main/java/com/graphaware/module/timetree/api/TimeTreeApi.java
+++ b/src/main/java/com/graphaware/module/timetree/api/TimeTreeApi.java
@@ -76,12 +76,15 @@ public class TimeTreeApi {
     public JsonNode getInstant(
             @PathVariable long time,
             @RequestParam(required = false) String resolution,
-            @RequestParam(required = false) String timezone) {
+			@RequestParam(required = false) String timezone) {
 
-        Node instant = timeTreeLogic.getInstant(time, resolution, timezone);
-
-        return getJsonNode(instant);
-    }
+		Node instant;
+		try (Transaction tx = database.beginTx();) {
+			instant = timeTreeLogic.getInstant(time, resolution, timezone);
+			tx.failure();
+		}
+		return getJsonNode(instant);
+	}
 
     @RequestMapping(value = "/single/{time}", method = RequestMethod.POST)
     @ResponseBody
@@ -101,12 +104,15 @@ public class TimeTreeApi {
             @PathVariable long startTime,
             @PathVariable long endTime,
             @RequestParam(required = false) String resolution,
-            @RequestParam(required = false) String timezone) {
+			@RequestParam(required = false) String timezone) {
 
-        List<Node> nodes = timeTreeLogic.getInstants(startTime, endTime, resolution, timezone);
-
-        return getJsonNodes(nodes);
-    }
+		List<Node> nodes;
+		try (Transaction tx = database.beginTx();) {
+			nodes = timeTreeLogic.getInstants(startTime, endTime, resolution, timezone);
+			tx.failure();
+		}
+		return getJsonNodes(nodes);
+	}
 
     @RequestMapping(value = "/range/{startTime}/{endTime}", method = RequestMethod.POST)
     @ResponseBody
@@ -127,12 +133,15 @@ public class TimeTreeApi {
             @PathVariable long rootNodeId,
             @PathVariable long time,
             @RequestParam(required = false) String resolution,
-            @RequestParam(required = false) String timezone) {
+			@RequestParam(required = false) String timezone) {
 
-        Node instant = timeTreeLogic.getInstantWithCustomRoot(rootNodeId, time, resolution, timezone);
-
-        return getJsonNode(instant);
-    }
+		Node instant;
+		try (Transaction tx = database.beginTx();) {
+			instant = timeTreeLogic.getInstantWithCustomRoot(rootNodeId, time, resolution, timezone);
+			tx.failure();
+		}
+		return getJsonNode(instant);
+	}
 
     @RequestMapping(value = "/{rootNodeId}/single/{time}", method = RequestMethod.POST)
     @ResponseBody
@@ -157,9 +166,12 @@ public class TimeTreeApi {
             @RequestParam(required = false) String resolution,
             @RequestParam(required = false) String timezone) {
 
-        List<Node> nodes = timeTreeLogic.getInstantsWithCustomRoot(rootNodeId, startTime, endTime, resolution, timezone);
-
-        return getJsonNodes(nodes);
+		List<Node> nodes;
+		try (Transaction tx = database.beginTx();) {
+			nodes = timeTreeLogic.getInstantsWithCustomRoot(rootNodeId, startTime, endTime, resolution, timezone);
+			tx.failure();
+		}
+		return getJsonNodes(nodes);
     }
 
     @RequestMapping(value = "/{rootNodeId}/range/{startTime}/{endTime}", method = RequestMethod.POST)

--- a/src/main/java/com/graphaware/module/timetree/module/TimeTreeConfiguration.java
+++ b/src/main/java/com/graphaware/module/timetree/module/TimeTreeConfiguration.java
@@ -15,20 +15,20 @@
  */
 package com.graphaware.module.timetree.module;
 
-import com.graphaware.common.policy.InclusionPolicies;
-import com.graphaware.common.policy.fluent.IncludeNodes;
-import com.graphaware.common.policy.fluent.IncludeRelationships;
-import com.graphaware.module.timetree.domain.Resolution;
-import com.graphaware.runtime.config.BaseTxDrivenModuleConfiguration;
-import com.graphaware.runtime.policy.InclusionPoliciesFactory;
+import static com.graphaware.module.timetree.domain.Resolution.DAY;
+
+import java.util.TimeZone;
+
 import org.joda.time.DateTimeZone;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.RelationshipType;
 
-import java.util.TimeZone;
-
-import static com.graphaware.module.timetree.domain.Resolution.DAY;
-import org.neo4j.graphdb.DynamicRelationshipType;
+import com.graphaware.common.policy.inclusion.InclusionPolicies;
+import com.graphaware.common.policy.inclusion.fluent.IncludeNodes;
+import com.graphaware.common.policy.inclusion.fluent.IncludeRelationships;
+import com.graphaware.module.timetree.domain.Resolution;
+import com.graphaware.runtime.config.BaseTxDrivenModuleConfiguration;
+import com.graphaware.runtime.policy.InclusionPoliciesFactory;
 
 
 /**

--- a/src/main/java/com/graphaware/module/timetree/module/TimeTreeModuleBootstrapper.java
+++ b/src/main/java/com/graphaware/module/timetree/module/TimeTreeModuleBootstrapper.java
@@ -16,20 +16,21 @@
 
 package com.graphaware.module.timetree.module;
 
-import com.graphaware.common.log.LoggerFactory;
-import com.graphaware.common.policy.NodeInclusionPolicy;
-import com.graphaware.module.timetree.domain.Resolution;
-import com.graphaware.runtime.config.function.StringToNodeInclusionPolicy;
-import com.graphaware.runtime.module.BaseRuntimeModuleBootstrapper;
-import com.graphaware.runtime.module.RuntimeModule;
+import java.util.Map;
+import java.util.TimeZone;
+
 import org.joda.time.DateTimeZone;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.logging.Log;
 
-import java.util.Map;
-import java.util.TimeZone;
+import com.graphaware.common.log.LoggerFactory;
+import com.graphaware.common.policy.inclusion.NodeInclusionPolicy;
+import com.graphaware.module.timetree.domain.Resolution;
+import com.graphaware.runtime.config.function.StringToNodeInclusionPolicy;
+import com.graphaware.runtime.module.BaseRuntimeModuleBootstrapper;
+import com.graphaware.runtime.module.RuntimeModule;
 
 /**
  * Bootstraps the {@link com.graphaware.module.timetree.module.TimeTreeModule} in server mode.

--- a/src/main/java/com/graphaware/module/timetree/proc/TimeTreeProcedure.java
+++ b/src/main/java/com/graphaware/module/timetree/proc/TimeTreeProcedure.java
@@ -15,22 +15,28 @@
  */
 package com.graphaware.module.timetree.proc;
 
-import com.graphaware.module.timetree.logic.TimeTreeBusinessLogic;
+import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureName;
+import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.neo4j.collection.RawIterator;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
-import org.neo4j.kernel.api.proc.*;
+import org.neo4j.kernel.api.proc.CallableProcedure;
+import org.neo4j.kernel.api.proc.Context;
+import org.neo4j.kernel.api.proc.Neo4jTypes;
+import org.neo4j.kernel.api.proc.QualifiedName;
+import org.neo4j.procedure.Mode;
 
-import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureName;
-import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
+import com.graphaware.module.timetree.logic.TimeTreeBusinessLogic;
 
 public class TimeTreeProcedure extends TimeTreeBaseProcedure {
 
@@ -44,7 +50,7 @@ public class TimeTreeProcedure extends TimeTreeBaseProcedure {
 
     public CallableProcedure.BasicProcedure get() {
         return new CallableProcedure.BasicProcedure(procedureSignature(getProcedureName("single"))
-                .mode(Mode.READ_WRITE)
+                .mode(Mode.WRITE)
                 .in(PARAMETER_NAME_INPUT, Neo4jTypes.NTMap)
                 .out(PARAMETER_NAME_INSTANT, Neo4jTypes.NTNode).build()) {
 
@@ -65,7 +71,7 @@ public class TimeTreeProcedure extends TimeTreeBaseProcedure {
 
     public CallableProcedure.BasicProcedure merge() {
         return new CallableProcedure.BasicProcedure(procedureSignature(getProcedureName("merge"))
-                .mode(Mode.READ_WRITE)
+                .mode(Mode.WRITE)
                 .in(PARAMETER_NAME_INPUT, Neo4jTypes.NTMap)
                 .out(PARAMETER_NAME_INSTANT, Neo4jTypes.NTNode).build()) {
 
@@ -106,7 +112,7 @@ public class TimeTreeProcedure extends TimeTreeBaseProcedure {
 
     public CallableProcedure.BasicProcedure getInstants() {
         return new CallableProcedure.BasicProcedure(procedureSignature(getProcedureName("range"))
-                .mode(Mode.READ_WRITE)
+                .mode(Mode.WRITE)
                 .in(PARAMETER_NAME_INPUT, Neo4jTypes.NTMap)
                 .out(PARAMETER_NAME_INSTANTS, Neo4jTypes.NTNode).build()) {
 
@@ -149,7 +155,7 @@ public class TimeTreeProcedure extends TimeTreeBaseProcedure {
     
     public CallableProcedure.BasicProcedure now() {
         return new CallableProcedure.BasicProcedure(procedureSignature(getProcedureName("now"))
-                .mode(Mode.READ_WRITE)
+                .mode(Mode.WRITE)
                 .in(PARAMETER_NAME_INPUT, Neo4jTypes.NTMap)
                 .out(PARAMETER_NAME_INSTANT, Neo4jTypes.NTNode).build()) {
 

--- a/src/main/java/com/graphaware/module/timetree/proc/TimeTreeProcedure.java
+++ b/src/main/java/com/graphaware/module/timetree/proc/TimeTreeProcedure.java
@@ -158,7 +158,7 @@ public class TimeTreeProcedure extends TimeTreeBaseProcedure {
                 checkIsMap(input[0]);
                 Map<String, Object> inputParams = (Map) input[0];
                 checkCreate(inputParams);
-                boolean create = true;
+                boolean create = (boolean) inputParams.getOrDefault(PARAMETER_NAME_CREATE, false);
                 Node rootNode = (Node) inputParams.getOrDefault(PARAMETER_NAME_ROOT, null);
                 String resolution = (String) inputParams.get(PARAMETER_NAME_RESOLUTION);
                 String timezone = (String) inputParams.get(PARAMETER_NAME_TIMEZONE);

--- a/src/main/java/com/graphaware/module/timetree/proc/TimedEventsProcedure.java
+++ b/src/main/java/com/graphaware/module/timetree/proc/TimedEventsProcedure.java
@@ -15,28 +15,29 @@
  */
 package com.graphaware.module.timetree.proc;
 
-import com.graphaware.module.timetree.TimedEvents;
-import com.graphaware.module.timetree.domain.Event;
-import com.graphaware.module.timetree.logic.TimedEventsBusinessLogic;
-import static com.graphaware.module.timetree.proc.TimeTreeBaseProcedure.PARAMETER_NAME_END_TIME;
-import static com.graphaware.module.timetree.proc.TimeTreeBaseProcedure.PARAMETER_NAME_ROOT;
-import static com.graphaware.module.timetree.proc.TimeTreeBaseProcedure.PARAMETER_NAME_START_TIME;
-import static com.graphaware.module.timetree.proc.TimeTreeBaseProcedure.PARAMETER_NAME_TIME;
+import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureName;
+import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
 import org.neo4j.collection.RawIterator;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
-import org.neo4j.kernel.api.proc.*;
+import org.neo4j.kernel.api.proc.CallableProcedure;
+import org.neo4j.kernel.api.proc.Context;
+import org.neo4j.kernel.api.proc.Neo4jTypes;
+import org.neo4j.kernel.api.proc.QualifiedName;
+import org.neo4j.procedure.Mode;
 
-import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureName;
-import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
+import com.graphaware.module.timetree.TimedEvents;
+import com.graphaware.module.timetree.domain.Event;
+import com.graphaware.module.timetree.logic.TimedEventsBusinessLogic;
 
 public class TimedEventsProcedure extends TimeTreeBaseProcedure {
 
@@ -48,7 +49,7 @@ public class TimedEventsProcedure extends TimeTreeBaseProcedure {
 
     public CallableProcedure.BasicProcedure getEvents() {
         return new CallableProcedure.BasicProcedure(procedureSignature(getProcedureName("single"))
-                .mode(Mode.READ_WRITE)
+                .mode(Mode.WRITE)
                 .in(PARAMETER_NAME_INPUT, Neo4jTypes.NTMap)
                 .out(PARAMETER_NAME_NODE, Neo4jTypes.NTNode)
                 .out(PARAMETER_NAME_RELATIONSHIP_TYPE, Neo4jTypes.NTString)
@@ -83,7 +84,7 @@ public class TimedEventsProcedure extends TimeTreeBaseProcedure {
 
     public CallableProcedure.BasicProcedure getAttach() {
         return new CallableProcedure.BasicProcedure(procedureSignature(getProcedureName("attach"))
-                .mode(Mode.READ_WRITE)
+                .mode(Mode.WRITE)
                 .in(PARAMETER_NAME_INPUT, Neo4jTypes.NTMap)
                 .out(PARAMETER_NAME_NODE, Neo4jTypes.NTNode)
                 .build()) {
@@ -118,7 +119,7 @@ public class TimedEventsProcedure extends TimeTreeBaseProcedure {
 
     public CallableProcedure.BasicProcedure getRangeEvents() {
         return new CallableProcedure.BasicProcedure(procedureSignature(getProcedureName("range"))
-                .mode(Mode.READ_WRITE)
+                .mode(Mode.WRITE)
                 .in(PARAMETER_NAME_INPUT, Neo4jTypes.NTMap)
                 .out(PARAMETER_NAME_NODE, Neo4jTypes.NTNode)
                 .out(PARAMETER_NAME_RELATIONSHIP_TYPE, Neo4jTypes.NTString)

--- a/src/test/java/com/graphaware/module/timetree/CustomRootTimeTreeTest.java
+++ b/src/test/java/com/graphaware/module/timetree/CustomRootTimeTreeTest.java
@@ -16,24 +16,28 @@
 
 package com.graphaware.module.timetree;
 
+import static com.graphaware.module.timetree.SingleTimeTree.VALUE_PROPERTY;
+import static com.graphaware.test.unit.GraphUnit.assertSameGraph;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.TimeZone;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.NotFoundException;
+import org.neo4j.graphdb.Transaction;
+
 import com.graphaware.common.util.PropertyContainerUtils;
 import com.graphaware.module.timetree.domain.TimeInstant;
 import com.graphaware.module.timetree.domain.TimeTreeLabels;
 import com.graphaware.test.data.DatabasePopulator;
 import com.graphaware.test.data.SingleTransactionPopulator;
 import com.graphaware.test.integration.EmbeddedDatabaseIntegrationTest;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.junit.Test;
-import org.neo4j.graphdb.*;
-
-import java.util.TimeZone;
-
-import static com.graphaware.module.timetree.SingleTimeTree.VALUE_PROPERTY;
-import com.graphaware.test.integration.ServerIntegrationTest;
-import static com.graphaware.test.unit.GraphUnit.assertSameGraph;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Unit test for {@link com.graphaware.module.timetree.SingleTimeTree}.

--- a/src/test/java/com/graphaware/module/timetree/ReadOnlySingleTimeTreeTest.java
+++ b/src/test/java/com/graphaware/module/timetree/ReadOnlySingleTimeTreeTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2013-2016 GraphAware
+ *
+ * This file is part of the GraphAware Framework.
+ *
+ * GraphAware Framework is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of
+ * the GNU General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.graphaware.module.timetree;
+
+import static com.graphaware.module.timetree.domain.Resolution.YEAR;
+import static com.graphaware.test.unit.GraphUnit.assertSameGraph;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+
+import com.graphaware.module.timetree.domain.Resolution;
+import com.graphaware.module.timetree.domain.TimeInstant;
+import com.graphaware.test.integration.EmbeddedDatabaseIntegrationTest;
+
+public class ReadOnlySingleTimeTreeTest extends EmbeddedDatabaseIntegrationTest {
+
+    private TimeTree timeTree; //class under test
+
+    private static final DateTimeZone UTC = DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC"));
+
+	private Transaction tx;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        timeTree = new SingleTimeTree(getDatabase());
+        tx = getDatabase().beginTx();
+    }
+
+    @After
+    public void tearDown(){
+    	tx.failure();
+    	tx.close();
+    }
+    
+    private long dateToMillis(int year, int month, int day) {
+        return dateToDateTime(year, month, day).getMillis();
+    }
+
+    private DateTime dateToDateTime(int year, int month, int day) {
+        return new DateTime(year, month, day, 0, 0, UTC);
+    }
+    
+    @Test
+    public void testGetInstantEmpty() {
+    	//Given
+        long dateInMillis = dateToMillis(2013, 5, 4);
+        TimeInstant timeInstant = TimeInstant.instant(dateInMillis).with(YEAR);
+
+        //When
+        Node yearNode;
+        yearNode = timeTree.getInstant(timeInstant);
+
+        //Then
+        assertNull(yearNode);
+        assertFalse(getDatabase().getAllNodes().iterator().hasNext());
+    }
+
+    @Test
+    public void testGetInstantOrAfterEmpty() {
+    	//Given
+        long dateInMillis = dateToMillis(2013, 5, 4);
+        TimeInstant timeInstant = TimeInstant.instant(dateInMillis).with(YEAR);
+
+        //When
+        Node yearNode;
+        yearNode = timeTree.getInstantAtOrAfter(timeInstant);
+
+        //Then
+        assertNull(yearNode);
+        assertFalse(getDatabase().getAllNodes().iterator().hasNext());
+    }
+
+    @Test
+    public void testGetInstantOrBeforeEmpty() {
+    	//Given
+        long dateInMillis = dateToMillis(2013, 5, 4);
+        TimeInstant timeInstant = TimeInstant.instant(dateInMillis).with(YEAR);
+
+        //When
+        Node yearNode;
+        yearNode = timeTree.getInstantAtOrBefore(timeInstant);
+
+        //Then
+        assertNull(yearNode);
+        assertFalse(getDatabase().getAllNodes().iterator().hasNext());
+    }
+    
+	private String populateTree(Long year, Long month, Long day) {
+		Transaction txc = getDatabase().beginTx();
+
+		String query = "CREATE" +
+                "(root:TimeTreeRoot)," +
+                "(root)-[:FIRST]->(year:Year {value: "+year+" })," +
+                "(root)-[:CHILD]->(year)," +
+                "(root)-[:LAST]->(year)," +
+                "(year)-[:FIRST]->(month:Month {value: "+month+" })," +
+                "(year)-[:CHILD]->(month)," +
+                "(year)-[:LAST]->(month)," +
+                "(month)-[:FIRST]->(day:Day {value: "+day+" })," +
+                "(month)-[:CHILD]->(day)," +
+                "(month)-[:LAST]->(day)";
+		
+		getDatabase().execute(query);
+        txc.success();
+        txc.close();
+        return query;
+	}
+
+    private Object[] getInstantParameters(final long year, final long month, final long day) {
+
+        return new Object[]{
+                new Object[]{Resolution.YEAR,year},
+                new Object[]{Resolution.MONTH,month},
+                new Object[]{Resolution.DAY,day},
+        };
+
+    }
+    
+    @Test
+    public void testGetInstant() {
+    	//Given
+        long dateInMillis = dateToMillis(2013, 5, 4);
+        
+        String tree = populateTree(2013L,5L,4L);
+    	
+    	//at the time of writing there's not available a JUnitParamsRunner so it uses an homemade trick 
+    	
+    	Object[] instantParameters = getInstantParameters(2013,5,4);
+    	for (Object params : instantParameters) {
+    		Object[] val = (Object[]) params;
+    		Resolution resolution = (Resolution) val[0];
+    		Long result = (Long) val[1];
+            
+            //When
+    		TimeInstant timeInstant = TimeInstant.instant(dateInMillis).with(resolution);
+            Node node=  timeTree.getInstant(timeInstant);
+
+            //Then
+            assertNotNull("Node not found at resolution: "+resolution,node);
+            assertEquals("Wrong resolution: "+resolution,result, node.getProperty("value"));
+		}
+    	
+    	//nothing is changed 
+    	assertSameGraph(getDatabase(), tree);
+    }
+    
+    @Test
+    public void testGetInstantBefore() {
+    	
+    	//Given
+        long dateInMillis = dateToMillis(2013, 5, 5);
+        
+        String tree = populateTree(2013L,5L,4L);
+    	
+    	//at the time of writing there's not available a JUnitParamsRunner so it uses an homemade trick 
+    	
+    	Object[] instantParameters = getInstantParameters(2013,5,4);
+    	for (Object params : instantParameters) {
+    		Object[] val = (Object[]) params;
+    		Resolution resolution = (Resolution) val[0];
+    		Long result = (Long) val[1];
+            
+            //When
+    		TimeInstant timeInstant = TimeInstant.instant(dateInMillis).with(resolution);
+            Node node=  timeTree.getInstantAtOrBefore(timeInstant);
+
+            //Then
+            assertNotNull("Node not found at resolution: "+resolution,node);
+            assertEquals("Wrong resolution: "+resolution,result, node.getProperty("value"));
+		}
+
+    	//nothing is changed 
+    	assertSameGraph(getDatabase(), tree);
+    }
+
+    @Test
+    public void testGetInstantAfter() {
+    	
+    	//Given
+        long dateInMillis = dateToMillis(2013, 5, 3);
+        
+        String tree = populateTree(2013L,5L,4L);
+    	
+    	//at the time of writing there's not available a JUnitParamsRunner so it uses an homemade trick 
+    	
+    	Object[] instantParameters = getInstantParameters(2013,5,4);
+    	for (Object params : instantParameters) {
+    		Object[] val = (Object[]) params;
+    		Resolution resolution = (Resolution) val[0];
+    		Long result = (Long) val[1];
+            
+            //When
+    		TimeInstant timeInstant = TimeInstant.instant(dateInMillis).with(resolution);
+            Node node=  timeTree.getInstantAtOrAfter(timeInstant);
+
+            //Then
+            assertNotNull("Node not found at resolution: "+resolution,node);
+            assertEquals("Wrong resolution: "+resolution,result, node.getProperty("value"));
+		}
+
+    	//nothing is changed 
+    	assertSameGraph(getDatabase(), tree);
+    }
+
+
+    @Test
+    public void testGetInstantsRange() {
+    	
+    	//Given
+        long dateFrom = dateToMillis(2013, 5, 3);
+        long dateTo = dateToMillis(2013, 5, 5);
+        
+        String tree = populateTree(2013L,5L,4L);
+    	
+    	//at the time of writing there's not available a JUnitParamsRunner so it uses an homemade trick 
+    	
+    	Object[] instantParameters = getInstantParameters(2013,5,4);
+    	for (Object params : instantParameters) {
+    		Object[] val = (Object[]) params;
+    		Resolution resolution = (Resolution) val[0];
+    		Long result = (Long) val[1];
+            
+            //When
+    		TimeInstant tf = TimeInstant.instant(dateFrom).with(resolution);
+    		TimeInstant tt = TimeInstant.instant(dateTo).with(resolution);
+    		List<Node> instants = timeTree.getInstants(tf, tt);
+
+    		assertNotNull(instants);
+    		assertEquals(1, instants.size());
+    		Node node = instants.get(0);
+            //Then
+            assertNotNull("Node not found at resolution: "+resolution,node);
+            assertEquals("Wrong resolution: "+resolution,result, node.getProperty("value"));
+		}
+    	
+    	//nothing is changed 
+    	assertSameGraph(getDatabase(), tree);
+    }
+}

--- a/src/test/java/com/graphaware/module/timetree/SingleTimeTreeTest.java
+++ b/src/test/java/com/graphaware/module/timetree/SingleTimeTreeTest.java
@@ -16,10 +16,22 @@
 
 package com.graphaware.module.timetree;
 
-import com.graphaware.common.util.PropertyContainerUtils;
-import com.graphaware.module.timetree.domain.TimeInstant;
-import com.graphaware.module.timetree.domain.TimeTreeLabels;
-import com.graphaware.test.integration.EmbeddedDatabaseIntegrationTest;
+import static com.graphaware.module.timetree.SingleTimeTree.VALUE_PROPERTY;
+import static com.graphaware.module.timetree.domain.Resolution.DAY;
+import static com.graphaware.module.timetree.domain.Resolution.HOUR;
+import static com.graphaware.module.timetree.domain.Resolution.MILLISECOND;
+import static com.graphaware.module.timetree.domain.Resolution.MONTH;
+import static com.graphaware.module.timetree.domain.Resolution.YEAR;
+import static com.graphaware.test.unit.GraphUnit.assertSameGraph;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.graphdb.RelationshipType.withName;
+
+import java.util.List;
+import java.util.TimeZone;
+
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
@@ -27,14 +39,10 @@ import org.junit.Test;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 
-import java.util.List;
-import java.util.TimeZone;
-
-import static com.graphaware.module.timetree.SingleTimeTree.VALUE_PROPERTY;
-import static com.graphaware.module.timetree.domain.Resolution.*;
-import static com.graphaware.test.unit.GraphUnit.assertSameGraph;
-import static org.junit.Assert.*;
-import static org.neo4j.graphdb.RelationshipType.withName;
+import com.graphaware.common.util.PropertyContainerUtils;
+import com.graphaware.module.timetree.domain.TimeInstant;
+import com.graphaware.module.timetree.domain.TimeTreeLabels;
+import com.graphaware.test.integration.EmbeddedDatabaseIntegrationTest;
 
 /**
  * Unit test for {@link SingleTimeTree}.
@@ -65,8 +73,12 @@ public class SingleTimeTreeTest extends EmbeddedDatabaseIntegrationTest {
         }
 
         //Then
-        assertNull(yearNode);
-        assertSameGraph(getDatabase(), "CREATE (root:TimeTreeRoot)");
+        try (Transaction tx = getDatabase().beginTx()) {
+        	assertNull(yearNode);
+            assertFalse(getDatabase().getAllNodes().iterator().hasNext());
+            tx.failure();
+        }
+        
 
         //When
         try (Transaction tx = getDatabase().beginTx()) {
@@ -74,9 +86,13 @@ public class SingleTimeTreeTest extends EmbeddedDatabaseIntegrationTest {
             tx.success();
         }
 
+        
         //Then
-        assertNull(yearNode);
-        assertSameGraph(getDatabase(), "CREATE (root:TimeTreeRoot)");
+        try (Transaction tx = getDatabase().beginTx()) {
+        	assertNull(yearNode);
+            assertFalse(getDatabase().getAllNodes().iterator().hasNext());
+            tx.failure();
+        }
 
         //When
         try (Transaction tx = getDatabase().beginTx()) {
@@ -85,8 +101,11 @@ public class SingleTimeTreeTest extends EmbeddedDatabaseIntegrationTest {
         }
 
         //Then
-        assertNull(yearNode);
-        assertSameGraph(getDatabase(), "CREATE (root:TimeTreeRoot)");
+        try (Transaction tx = getDatabase().beginTx()) {
+        	assertNull(yearNode);
+            assertFalse(getDatabase().getAllNodes().iterator().hasNext());
+            tx.failure();
+        }
     }
 
     @Test
@@ -103,8 +122,11 @@ public class SingleTimeTreeTest extends EmbeddedDatabaseIntegrationTest {
         }
 
         //Then
-        assertNull(dayNode);
-        assertSameGraph(getDatabase(), "CREATE (root:TimeTreeRoot)");
+        try (Transaction tx = getDatabase().beginTx()) {
+        	assertNull(dayNode);
+            assertFalse(getDatabase().getAllNodes().iterator().hasNext());
+            tx.failure();
+        }
 
         //When
         try (Transaction tx = getDatabase().beginTx()) {
@@ -113,8 +135,12 @@ public class SingleTimeTreeTest extends EmbeddedDatabaseIntegrationTest {
         }
 
         //Then
-        assertNull(dayNode);
-        assertSameGraph(getDatabase(), "CREATE (root:TimeTreeRoot)");
+        try (Transaction tx = getDatabase().beginTx()) {
+        	assertNull(dayNode);
+            assertFalse(getDatabase().getAllNodes().iterator().hasNext());
+            tx.failure();
+        }
+
 
         //When
         try (Transaction tx = getDatabase().beginTx()) {
@@ -123,8 +149,12 @@ public class SingleTimeTreeTest extends EmbeddedDatabaseIntegrationTest {
         }
 
         //Then
-        assertNull(dayNode);
-        assertSameGraph(getDatabase(), "CREATE (root:TimeTreeRoot)");
+        try (Transaction tx = getDatabase().beginTx()) {
+        	assertNull(dayNode);
+            assertFalse(getDatabase().getAllNodes().iterator().hasNext());
+            tx.failure();
+        }
+
     }
 
     @Test

--- a/src/test/java/com/graphaware/module/timetree/api/TimeTreeApiWithUUIDTest.java
+++ b/src/test/java/com/graphaware/module/timetree/api/TimeTreeApiWithUUIDTest.java
@@ -16,9 +16,12 @@
 
 package com.graphaware.module.timetree.api;
 
-import com.graphaware.common.policy.InclusionPolicies;
-import com.graphaware.common.policy.NodePropertyInclusionPolicy;
-import com.graphaware.test.integration.GraphAwareIntegrationTest;
+import static com.graphaware.test.unit.GraphUnit.assertSameGraph;
+import static org.neo4j.graphdb.Label.label;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.http.HttpStatus;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -30,11 +33,9 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.graphdb.event.TransactionEventHandler;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static com.graphaware.test.unit.GraphUnit.assertSameGraph;
-import static org.neo4j.graphdb.Label.label;
-import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+import com.graphaware.common.policy.inclusion.InclusionPolicies;
+import com.graphaware.common.policy.inclusion.NodePropertyInclusionPolicy;
+import com.graphaware.test.integration.GraphAwareIntegrationTest;
 
 /**
  * Integration test for {@link TimeTreeApi}.

--- a/src/test/java/com/graphaware/module/timetree/api/TimedEventsApiWithUUIDTest.java
+++ b/src/test/java/com/graphaware/module/timetree/api/TimedEventsApiWithUUIDTest.java
@@ -16,11 +16,13 @@
 
 package com.graphaware.module.timetree.api;
 
-import com.graphaware.common.policy.InclusionPolicies;
-import com.graphaware.common.policy.NodePropertyInclusionPolicy;
-import com.graphaware.module.timetree.domain.Resolution;
-import com.graphaware.module.timetree.domain.TimeInstant;
-import com.graphaware.test.integration.GraphAwareIntegrationTest;
+import static com.graphaware.test.unit.GraphUnit.assertSameGraph;
+import static org.neo4j.graphdb.Label.label;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.http.HttpStatus;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -32,12 +34,11 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.graphdb.event.TransactionEventHandler;
 
-import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static com.graphaware.test.unit.GraphUnit.assertSameGraph;
-import static org.neo4j.graphdb.Label.label;
-import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+import com.graphaware.common.policy.inclusion.InclusionPolicies;
+import com.graphaware.common.policy.inclusion.NodePropertyInclusionPolicy;
+import com.graphaware.module.timetree.domain.Resolution;
+import com.graphaware.module.timetree.domain.TimeInstant;
+import com.graphaware.test.integration.GraphAwareIntegrationTest;
 
 /**
  * Integration test for {@link TimeTreeApi}.

--- a/src/test/java/com/graphaware/module/timetree/module/IncludeEvents.java
+++ b/src/test/java/com/graphaware/module/timetree/module/IncludeEvents.java
@@ -16,12 +16,14 @@
 
 package com.graphaware.module.timetree.module;
 
-import com.graphaware.common.policy.BaseNodeInclusionPolicy;
+import static org.neo4j.graphdb.Label.label;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
-import static org.neo4j.graphdb.Label.label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.helpers.collection.Iterators;
+
+import com.graphaware.common.policy.inclusion.BaseNodeInclusionPolicy;
 
 public final class IncludeEvents extends BaseNodeInclusionPolicy {
 

--- a/src/test/java/com/graphaware/module/timetree/module/TimeTreeConfigurationTest.java
+++ b/src/test/java/com/graphaware/module/timetree/module/TimeTreeConfigurationTest.java
@@ -16,12 +16,13 @@
 
 package com.graphaware.module.timetree.module;
 
-import com.graphaware.common.policy.composite.CompositeNodeInclusionPolicy;
-import com.graphaware.common.policy.spel.SpelNodeInclusionPolicy;
-import org.junit.Test;
-
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 import org.neo4j.graphdb.RelationshipType;
+
+import com.graphaware.common.policy.inclusion.composite.CompositeNodeInclusionPolicy;
+import com.graphaware.common.policy.inclusion.spel.SpelNodeInclusionPolicy;
 
 /**
  * Unit test for {@link com.graphaware.module.timetree.module.TimeTreeConfiguration}

--- a/src/test/java/com/graphaware/module/timetree/module/TimeTreeModuleMultiRootProgrammaticTest.java
+++ b/src/test/java/com/graphaware/module/timetree/module/TimeTreeModuleMultiRootProgrammaticTest.java
@@ -16,30 +16,34 @@
 
 package com.graphaware.module.timetree.module;
 
+import static com.graphaware.module.timetree.domain.Resolution.MONTH;
+import static com.graphaware.test.unit.GraphUnit.assertSameGraph;
+import static org.neo4j.graphdb.Label.label;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+
 import com.graphaware.common.kv.GraphKeyValueStore;
 import com.graphaware.common.kv.KeyValueStore;
-import com.graphaware.common.policy.BaseNodeInclusionPolicy;
+import com.graphaware.common.policy.inclusion.BaseNodeInclusionPolicy;
 import com.graphaware.common.serialize.Serializer;
 import com.graphaware.module.timetree.domain.Resolution;
 import com.graphaware.runtime.GraphAwareRuntime;
 import com.graphaware.runtime.GraphAwareRuntimeFactory;
 import com.graphaware.runtime.metadata.DefaultTxDrivenModuleMetadata;
-import org.joda.time.DateTimeZone;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.neo4j.graphdb.*;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
-
-import java.io.IOException;
-import java.util.Calendar;
-import java.util.TimeZone;
-
-import static com.graphaware.module.timetree.domain.Resolution.MONTH;
 import com.graphaware.test.integration.EmbeddedDatabaseIntegrationTest;
-import static com.graphaware.test.unit.GraphUnit.assertSameGraph;
-import static org.neo4j.graphdb.Label.*;
-
-import java.io.File;
 
 /**
  * Test for {@link TimeTreeModule} set up programatically.

--- a/src/test/java/com/graphaware/module/timetree/module/TimeTreeModuleSingleRootProgrammaticTest.java
+++ b/src/test/java/com/graphaware/module/timetree/module/TimeTreeModuleSingleRootProgrammaticTest.java
@@ -16,32 +16,36 @@
 
 package com.graphaware.module.timetree.module;
 
-import com.graphaware.common.kv.GraphKeyValueStore;
-import com.graphaware.common.kv.KeyValueStore;
-import com.graphaware.common.policy.BaseNodeInclusionPolicy;
-import com.graphaware.common.serialize.Serializer;
-import com.graphaware.runtime.GraphAwareRuntime;
-import com.graphaware.runtime.GraphAwareRuntimeFactory;
-import com.graphaware.runtime.metadata.DefaultTxDrivenModuleMetadata;
-import org.joda.time.DateTimeZone;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.neo4j.graphdb.*;
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import static com.graphaware.module.timetree.domain.Resolution.MINUTE;
+import static com.graphaware.module.timetree.domain.Resolution.MONTH;
+import static com.graphaware.test.unit.GraphUnit.assertSameGraph;
+import static org.neo4j.graphdb.Label.label;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
-import static com.graphaware.module.timetree.domain.Resolution.MINUTE;
-import static com.graphaware.module.timetree.domain.Resolution.MONTH;
-import com.graphaware.test.integration.EmbeddedDatabaseIntegrationTest;
-import static com.graphaware.test.unit.GraphUnit.assertSameGraph;
-import static org.neo4j.graphdb.Label.*;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 
-import java.io.File;
+import com.graphaware.common.kv.GraphKeyValueStore;
+import com.graphaware.common.kv.KeyValueStore;
+import com.graphaware.common.policy.inclusion.BaseNodeInclusionPolicy;
+import com.graphaware.common.serialize.Serializer;
+import com.graphaware.runtime.GraphAwareRuntime;
+import com.graphaware.runtime.GraphAwareRuntimeFactory;
+import com.graphaware.runtime.metadata.DefaultTxDrivenModuleMetadata;
+import com.graphaware.test.integration.EmbeddedDatabaseIntegrationTest;
 
 /**
  * Test for {@link com.graphaware.module.timetree.module.TimeTreeModule} set up programatically.

--- a/src/test/java/com/graphaware/module/timetree/proc/TimeTreeProcedureTest.java
+++ b/src/test/java/com/graphaware/module/timetree/proc/TimeTreeProcedureTest.java
@@ -78,7 +78,7 @@ public class TimeTreeProcedureTest extends GraphAwareIntegrationTest {
         try (Transaction tx = getDatabase().beginTx()) {
             Result result = getDatabase().execute("CALL ga.timetree.now({resolution: {resolution}, timezone: {timezone}}) YIELD instant return instant", params);
             ResourceIterator<Node> resIterator = result.columnAs("instant");
-            assertTrue(resIterator.hasNext());
+            assertFalse(resIterator.hasNext());
             tx.success();
         }
 

--- a/src/test/java/com/graphaware/module/timetree/proc/TimeTreeProcsTestCausalCluster.java
+++ b/src/test/java/com/graphaware/module/timetree/proc/TimeTreeProcsTestCausalCluster.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2013-2016 GraphAware
+ *
+ * This file is part of the GraphAware Framework.
+ *
+ * GraphAware Framework is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of
+ * the GNU General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package com.graphaware.module.timetree.proc;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+
+import com.graphaware.module.timetree.module.TimeTreeConfiguration;
+import com.graphaware.module.timetree.module.TimeTreeModule;
+import com.graphaware.runtime.GraphAwareRuntime;
+import com.graphaware.runtime.GraphAwareRuntimeFactory;
+import com.graphaware.test.integration.cluster.CausalClusterDatabasesintegrationTest;
+
+/**
+ * Test the read-only procedures in all kind of instances - Causal Cluster
+ * ga.timetree.now - in no-leader instance threw write-permission exception
+ */
+public class TimeTreeProcsTestCausalCluster extends CausalClusterDatabasesintegrationTest {
+
+	@Override
+	protected boolean shouldRegisterModules() {
+		return true;
+	}
+
+	@Override
+	protected void registerModule(GraphDatabaseService database) throws Exception {
+		GraphAwareRuntime runtime = GraphAwareRuntimeFactory.createRuntime(database);
+		runtime.registerModule(new TimeTreeModule("timetree", TimeTreeConfiguration.defaultConfiguration(), database));
+		runtime.start();
+
+		TimeTreeProcedures.register(database);
+	}
+
+	@Test
+	public void testNowReadOnly_LEADER() {
+		GraphDatabaseService db = getLeaderDatabase();
+		Result execute = db.execute("CALL ga.timetree.now({create: false}) YIELD instant RETURN instant");
+		assertFalse(execute.hasNext());
+	}
+
+	@Test
+	public void testNowReadOnly_FOLLOWER() {
+		GraphDatabaseService db = getOneFollowerDatabase();
+		Result execute = db.execute("CALL ga.timetree.now({create: false}) YIELD instant RETURN instant");
+		assertFalse(execute.hasNext());
+	}
+	
+	@Test
+	public void testNowReadOnly_REPLICA() {
+		GraphDatabaseService db = getOneReplicaDatabase();
+		Result execute = db.execute("CALL ga.timetree.now({create: false}) YIELD instant RETURN instant");
+		assertFalse(execute.hasNext());
+	}
+
+	@Test
+	public void testGetReadOnly_LEADER() {
+		GraphDatabaseService db = getLeaderDatabase();
+		Result execute = db.execute("CALL ga.timetree.single({time: 1463659567468}) YIELD instant RETURN instant");
+		assertFalse(execute.hasNext());
+	}
+
+	@Test
+	public void testGetReadOnly_FOLLOWER() {
+		GraphDatabaseService db = getOneFollowerDatabase();
+		Result execute = db.execute("CALL ga.timetree.single({time: 1463659567468}) YIELD instant RETURN instant");
+		assertFalse(execute.hasNext());
+	}
+
+	@Test
+	public void testGetReadOnly_REPLICA() {
+		GraphDatabaseService db = getOneReplicaDatabase();
+		Result execute = db.execute("CALL ga.timetree.single({time: 1463659567468}) YIELD instant RETURN instant");
+		assertFalse(execute.hasNext());
+	}
+
+	@Test
+	public void testRangeReadOnly_LEADER() {
+		GraphDatabaseService db = getLeaderDatabase();
+		Result execute = db
+				.execute("CALL ga.timetree.range({start: 1463659567468, end: 1463859569504, create: false})");
+		assertFalse(execute.hasNext());
+	}
+
+	@Test
+	public void testRangeReadOnly_FOLLOWER() {
+		GraphDatabaseService db = getOneFollowerDatabase();
+		Result execute = db
+				.execute("CALL ga.timetree.range({start: 1463659567468, end: 1463859569504, create: false})");
+		assertFalse(execute.hasNext());
+	}
+
+	@Test
+	public void testRangeReadOnly_REPLICA() {
+		GraphDatabaseService db = getOneReplicaDatabase();
+		Result execute = db
+				.execute("CALL ga.timetree.range({start: 1463659567468, end: 1463859569504, create: false})");
+		assertFalse(execute.hasNext());
+	}
+}


### PR DESCRIPTION
The causal cluster test need the newest version in the framework branch "causal-cluster".
I changed the SingleTimeTree in order to split read-only from writable operations.